### PR TITLE
fix: parentId is now a string, and fix Area settings page

### DIFF
--- a/lib/cells/repository/cell_repository.dart
+++ b/lib/cells/repository/cell_repository.dart
@@ -50,7 +50,7 @@ class CellRepository {
         "is_tracked": true,
         "last_update_at": "2026-01-09 09:46:26",
         "location": "Champ #1 > Parcelle #3 > Planche A", // TODO: à supprimer
-        "parent_id": 3,
+        "parent_id": "3",
         "analytics": {
           "air_temperature": [
             {"value": 18, "occurred_at": "2025-11-05T08:00:00Z", "sensor_id": 12, "alert_status":  "ALERT"}
@@ -85,7 +85,7 @@ class CellRepository {
       "is_tracked": true,
       "last_update_at": "2026-01-09 09:46:26",
       "location": "Champ #1 > Parcelle #3 > Planche A", // TODO: à supprimer
-      "parent_id": 3,
+      "parent_id": "3",
       "analytics": {
         "air_temperature": [
           {

--- a/lib/common/models/base_item.dart
+++ b/lib/common/models/base_item.dart
@@ -4,7 +4,7 @@ class BaseItem {
   final String id;
   final String name;
   final Analytics analytics;
-  int? parentId;
+  String? parentId;
   final bool isTracked;
 
   BaseItem({

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -144,7 +144,7 @@ class AppRouter {
                           state.uri.queryParameters['view'] == 'true';
                       return NoTransitionPage(
                         child: AreaAddEditPage(
-                          id: int.parse(state.pathParameters['id']!),
+                          id: state.pathParameters['id']!,
                           isViewMode: viewMode,
                         ),
                       );

--- a/lib/settings/area/page/area_add_edit_page.dart
+++ b/lib/settings/area/page/area_add_edit_page.dart
@@ -11,7 +11,7 @@ import '../../../common/widgets/base_item_edit_form_card.dart';
 import '../../../common/widgets/danger_zone.dart';
 
 class AreaAddEditPage extends StatelessWidget {
-  final int? id;
+  final String? id;
   final bool isViewMode;
 
   const AreaAddEditPage({super.key, this.id, this.isViewMode = false});


### PR DESCRIPTION
fixes : 

- BaseItem.parentId is now a string
- "/settings/areas/:id" page was broken after the conversion of all ids to string